### PR TITLE
新規記録作成、記録詳細、記録編集、パスワードリセット画面のデザインを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,7 @@ group :test do
   gem "selenium-webdriver"
   gem "minitest", "~> 5.20"
 end
+
+group :development do
+  gem "letter_opener_web"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.5.1)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -131,6 +133,17 @@ GEM
       activesupport (>= 7.0.0)
     json (2.18.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.0)
@@ -354,6 +367,7 @@ DEPENDENCIES
   devise
   importmap-rails
   jbuilder
+  letter_opener_web
   minitest (~> 5.20)
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,34 @@
-<h2>Change your password</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+<div class="min-h-screen bg-white flex flex-col">
+  <div class="w-full py-6 bg-green-50 text-center">
+    <h1 class="text-2xl font-bold text-gray-800">ありがとう貯金</h1>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  <div class="flex-1 flex items-center justify-center px-4">
+    <div class="w-full max-w-md">
+      <h2 class="text-2xl font-bold text-gray-800 text-center mb-8">パスワードを変更</h2>
+
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
+
+        <div class="mb-6">
+          <%= f.label :password, "新しいパスワード", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div class="mb-8">
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div class="mb-6">
+          <%= f.submit "パスワードを変更", class: "w-full px-6 py-3 bg-green-400 text-white rounded-full font-medium hover:bg-green-500 transition cursor-pointer" %>
+        </div>
+      <% end %>
+    </div>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
+  <div class="w-full text-center py-6 text-gray-400 text-sm bg-green-50">
+    © 2026 ありがとう貯金
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,33 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="min-h-screen bg-white flex flex-col">
+  <div class="w-full py-6 bg-green-50 text-center">
+    <h1 class="text-2xl font-bold text-gray-800">ありがとう貯金</h1>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+  <div class="flex-1 flex items-center justify-center px-4">
+    <div class="w-full max-w-md">
+      <h2 class="text-2xl font-bold text-gray-800 text-center mb-4">パスワードを忘れた方</h2>
+      
+      <p class="text-gray-600 text-center mb-8">
+        登録したメールアドレスに<br>
+        パスワード再設定用のリンクを送信します
+      </p>
 
-<%= render "devise/shared/links" %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <div class="mb-6">
+          <%= f.label :email, "メールアドレス", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div class="mb-6">
+          <%= f.submit "送信", class: "w-full px-6 py-3 bg-green-400 text-white rounded-full font-medium hover:bg-green-500 transition cursor-pointer" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="w-full text-center py-6 text-gray-400 text-sm bg-green-50">
+    © 2026 ありがとう貯金
+  </div>
+</div>

--- a/app/views/thanks/edit.html.erb
+++ b/app/views/thanks/edit.html.erb
@@ -1,41 +1,52 @@
-<div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold mb-6">ありがとう記録の編集</h1>
+<div class="min-h-screen bg-white flex flex-col">
+  <div class="w-full py-6 bg-green-50 text-center">
+    <h1 class="text-2xl font-bold text-gray-800">ありがとう貯金</h1>
+  </div>
 
-  <%= form_with model: @thank, local: true, class: "bg-white shadow-md rounded-lg p-6" do |f| %>
-    <% if @thank.errors.any? %>
-      <div class="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded">
-        <h2 class="font-bold mb-2"><%= pluralize(@thank.errors.count, "error") %> prohibited this record from being saved:</h2>
-        <ul class="list-disc list-inside">
-          <% @thank.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+  <div class="flex-1 px-4 py-8">
+    <div class="max-w-md mx-auto">
+      <h2 class="text-2xl font-bold text-gray-800 text-center mb-8">記録を編集</h2>
 
-    <div class="mb-4">
-      <%= f.label :date, "日付", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= f.date_field :date, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500" %>
+      <%= form_with(model: @thank, local: true, class: "space-y-6") do |f| %>
+        <% if @thank.errors.any? %>
+          <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg">
+            <ul class="list-disc list-inside">
+              <% @thank.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div>
+          <%= f.label :date, "日付", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.date_field :date, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div>
+          <%= f.label :from_who, "誰から", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.text_field :from_who, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div>
+          <%= f.label :situation, "シチュエーション", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.text_area :situation, rows: 4, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div>
+          <%= f.label :feeling, "自分の気持ち・メモ", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.text_area :feeling, rows: 4, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div class="space-y-3">
+          <%= f.submit "更新", class: "w-full px-6 py-3 bg-green-400 text-white rounded-full hover:bg-green-500 cursor-pointer" %>
+          <%= link_to "キャンセル", thank_path(@thank), class: "block w-full px-6 py-3 bg-white border-2 border-gray-300 text-gray-700 rounded-full text-center hover:bg-gray-50" %>
+        </div>
+      <% end %>
     </div>
+  </div>
 
-    <div class="mb-4">
-      <%= f.label :from_who, "誰から", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= f.text_field :from_who, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500" %>
-    </div>
-
-    <div class="mb-4">
-      <%= f.label :situation, "どんな場面", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= f.text_area :situation, rows: 4, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500" %>
-    </div>
-
-    <div class="mb-6">
-      <%= f.label :feeling, "そのときの気持ち(任意)", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= f.text_area :feeling, rows: 4, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500" %>
-    </div>
-
-    <div class="flex gap-4">
-      <%= f.submit "更新する", class: "bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded cursor-pointer" %>
-      <%= link_to 'キャンセル', thank_path(@thank), class: "bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
-    </div>
-  <% end %>
+  <div class="w-full text-center py-6 text-gray-400 text-sm bg-green-50">
+    © 2026 ありがとう貯金
+  </div>
 </div>

--- a/app/views/thanks/new.html.erb
+++ b/app/views/thanks/new.html.erb
@@ -1,41 +1,52 @@
-<div class="max-w-2xl mx-auto px-4 py-8">
-  <h1 class="text-3xl font-bold text-gray-800 mb-6">ありがとう記録を追加</h1>
+<div class="min-h-screen bg-white flex flex-col">
+  <div class="w-full py-6 bg-green-50 text-center">
+    <h1 class="text-2xl font-bold text-gray-800">ありがとう貯金</h1>
+  </div>
 
-  <%= form_with(model: @thank, local: true, class: "space-y-6") do |f| %>
-    <% if @thank.errors.any? %>
-      <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded">
-        <h2 class="font-bold mb-2"><%= pluralize(@thank.errors.count, "個のエラー") %>があります</h2>
-        <ul class="list-disc list-inside">
-          <% @thank.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+  <div class="flex-1 px-4 py-8">
+    <div class="max-w-md mx-auto">
+      <h2 class="text-2xl font-bold text-gray-800 text-center mb-8">新しい記録を作成</h2>
 
-    <div>
-      <%= f.label :date, "日付", class: "block text-gray-700 font-bold mb-2" %>
-      <%= f.date_field :date, class: "w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500" %>
+      <%= form_with(model: @thank, local: true, class: "space-y-6") do |f| %>
+        <% if @thank.errors.any? %>
+          <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg">
+            <ul class="list-disc list-inside">
+              <% @thank.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div>
+          <%= f.label :date, "日付", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.date_field :date, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div>
+          <%= f.label :from_who, "誰から", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.text_field :from_who, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div>
+          <%= f.label :situation, "どんなシチュエーションで言われた？", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.text_area :situation, rows: 4, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div>
+          <%= f.label :feeling, "自分の気持ち・メモ", class: "block text-gray-700 font-medium mb-2" %>
+          <%= f.text_area :feeling, rows: 4, class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400" %>
+        </div>
+
+        <div class="space-y-3">
+          <%= f.submit "保存", class: "w-full px-6 py-3 bg-green-400 text-white rounded-full hover:bg-green-500 cursor-pointer" %>
+          <%= link_to "キャンセル", root_path, class: "block w-full px-6 py-3 bg-white border-2 border-gray-300 text-gray-700 rounded-full text-center hover:bg-gray-50" %>
+        </div>
+      <% end %>
     </div>
+  </div>
 
-    <div>
-      <%= f.label :from_who, "誰から", class: "block text-gray-700 font-bold mb-2" %>
-      <%= f.text_field :from_who, placeholder: "例: 同僚の田中さん", class: "w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500" %>
-    </div>
-
-    <div>
-      <%= f.label :situation, "どんな状況で", class: "block text-gray-700 font-bold mb-2" %>
-      <%= f.text_area :situation, rows: 4, placeholder: "例: プロジェクトの資料作成を手伝ってくれた", class: "w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500" %>
-    </div>
-
-    <div>
-      <%= f.label :feeling, "どう感じたか（任意）", class: "block text-gray-700 font-bold mb-2" %>
-      <%= f.text_area :feeling, rows: 4, placeholder: "例: とても助かった。感謝の気持ちでいっぱい", class: "w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500" %>
-    </div>
-
-    <div class="flex gap-4">
-      <%= f.submit "保存", class: "bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-6 rounded cursor-pointer" %>
-      <%= link_to "キャンセル", root_path, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-6 rounded" %>
-    </div>
-  <% end %>
+  <div class="w-full text-center py-6 text-gray-400 text-sm bg-green-50">
+    © 2026 ありがとう貯金
+  </div>
 </div>

--- a/app/views/thanks/show.html.erb
+++ b/app/views/thanks/show.html.erb
@@ -1,33 +1,52 @@
-<div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold mb-6">ありがとう記録の詳細</h1>
-
-  <div class="bg-white shadow-md rounded-lg p-6 mb-6">
-    <div class="mb-4">
-      <p class="text-sm text-gray-600 mb-1">日付</p>
-      <p class="text-lg font-semibold"><%= @thank.date.strftime('%Y年%m月%d日') %></p>
-    </div>
-
-    <div class="mb-4">
-      <p class="text-sm text-gray-600 mb-1">誰から</p>
-      <p class="text-lg"><%= @thank.from_who %></p>
-    </div>
-
-    <div class="mb-4">
-      <p class="text-sm text-gray-600 mb-1">どんな場面</p>
-      <p class="text-lg whitespace-pre-wrap"><%= @thank.situation %></p>
-    </div>
-
-    <% if @thank.feeling.present? %>
-      <div class="mb-4">
-        <p class="text-sm text-gray-600 mb-1">そのときの気持ち</p>
-        <p class="text-lg whitespace-pre-wrap"><%= @thank.feeling %></p>
-      </div>
-    <% end %>
+<div class="min-h-screen bg-white flex flex-col">
+  <div class="w-full py-6 bg-green-50 text-center">
+    <h1 class="text-2xl font-bold text-gray-800">ありがとう貯金</h1>
   </div>
 
-  <div class="flex gap-4">
-    <%= link_to '編集', edit_thank_path(@thank), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded' %>
-    <%= button_to '削除', thank_path(@thank), method: :delete, data: { turbo_confirm: '本当に削除しますか?' }, class: 'bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded' %>
-    <%= link_to '一覧に戻る', thanks_path, class: 'bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded' %>
+  <div class="w-full py-4 bg-white border-b">
+    <div class="max-w-7xl mx-auto px-4 flex justify-center gap-4">
+      <%= link_to "記録一覧", thanks_path, class: "px-6 py-2 rounded-full bg-green-400 text-white hover:bg-green-500" %>
+      <%= link_to "マイページ", edit_user_registration_path, class: "px-6 py-2 rounded-full bg-green-400 text-white hover:bg-green-500" %>
+      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "px-6 py-2 rounded-full bg-green-400 text-white hover:bg-green-500" %>
+    </div>
+  </div>
+
+  <div class="flex-1 px-4 py-8">
+    <div class="max-w-2xl mx-auto">
+      <h2 class="text-2xl font-bold text-gray-800 text-center mb-8">記録詳細</h2>
+
+      <div class="bg-gray-50 rounded-lg p-8 mb-8">
+        <div class="mb-6">
+          <p class="text-gray-600 mb-2"><%= @thank.date.strftime('%Y年%m月%d日') %></p>
+        </div>
+
+        <div class="mb-6">
+          <p class="text-gray-700 mb-2"><strong>誰から</strong></p>
+          <p class="text-gray-700"><%= @thank.from_who %>さんから</p>
+        </div>
+
+        <div class="mb-6">
+          <p class="text-gray-700 mb-2"><strong>どんなシチュエーションで言われた？</strong></p>
+          <p class="text-gray-700 whitespace-pre-wrap"><%= @thank.situation %></p>
+        </div>
+
+        <% if @thank.feeling.present? %>
+          <div>
+            <p class="text-gray-700 mb-2"><strong>自分の気持ち</strong></p>
+            <p class="text-gray-700 whitespace-pre-wrap"><%= @thank.feeling %></p>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="flex justify-center gap-4">
+        <%= link_to '編集', edit_thank_path(@thank), class: 'px-8 py-3 bg-green-400 text-white rounded-full hover:bg-green-500' %>
+        <%= button_to '削除', thank_path(@thank), method: :delete, data: { turbo_confirm: '本当に削除しますか?' }, class: 'px-8 py-3 bg-red-400 text-white rounded-full hover:bg-red-500 cursor-pointer' %>
+        <%= link_to '一覧に戻る', thanks_path, class: 'px-8 py-3 bg-gray-400 text-white rounded-full hover:bg-gray-500' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="w-full text-center py-6 text-gray-400 text-sm bg-green-50">
+    © 2026 ありがとう貯金
   </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  # 開発環境のみ
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   devise_for :users
 
   root "static_pages#top"


### PR DESCRIPTION
## 概要
新規記録作成、記録詳細、記録編集、パスワードリセット関連ページのデザインを統一

## 変更内容
- 新規記録作成ページのデザインを修正
- 記録詳細ページのデザインを修正
- 記録編集ページのデザインを修正
- パスワードリセット申請ページのデザインを修正
- パスワード変更ページのデザインを修正
  